### PR TITLE
Fix postcard glitching out

### DIFF
--- a/ImGuiManager.cs
+++ b/ImGuiManager.cs
@@ -31,6 +31,8 @@ public class ImGuiManager {
             renderTarget = new RenderTarget2D(Engine.Instance.GraphicsDevice, expectedWidth, expectedHeight, false, SurfaceFormat.Color, DepthFormat.Depth24Stencil8, 0, RenderTargetUsage.DiscardContents);
         }
 
+        var previousRenderTarget = Engine.Instance.GraphicsDevice.GetRenderTargets();
+
         Engine.Graphics.GraphicsDevice.SetRenderTarget(renderTarget);
         Engine.Graphics.GraphicsDevice.Clear(Color.Transparent);
 
@@ -41,6 +43,8 @@ public class ImGuiManager {
             }
         }
         renderer.AfterLayout();
+
+        Engine.Graphics.GraphicsDevice.SetRenderTargets(previousRenderTarget);
 
         WantCaptureKeyboard = ImGui.GetIO().WantCaptureKeyboard;
     }

--- a/ImGuiRenderer.cs
+++ b/ImGuiRenderer.cs
@@ -303,6 +303,9 @@ public sealed class ImGuiRenderer {
         // Setup render state: alpha-blending enabled, no face culling, no depth testing, scissor enabled, vertex/texcoord/color pointers
         var lastViewport = graphicsDevice.Viewport;
         var lastScissorBox = graphicsDevice.ScissorRectangle;
+        var lastRasterizerState = graphicsDevice.RasterizerState;
+        var lastDepthStencilState = graphicsDevice.DepthStencilState;
+        var lastBlendState = graphicsDevice.BlendState;
 
         graphicsDevice.BlendFactor = Color.White;
         graphicsDevice.BlendState = BlendState.NonPremultiplied;
@@ -322,6 +325,9 @@ public sealed class ImGuiRenderer {
         // Restore modified state
         graphicsDevice.Viewport = lastViewport;
         graphicsDevice.ScissorRectangle = lastScissorBox;
+        graphicsDevice.RasterizerState = lastRasterizerState;
+        graphicsDevice.DepthStencilState = lastDepthStencilState;
+        graphicsDevice.BlendState = lastBlendState;
     }
 
     private unsafe void UpdateBuffers(ImDrawDataPtr drawData) {

--- a/lib-stripped/.gitignore
+++ b/lib-stripped/.gitignore
@@ -1,0 +1,1 @@
+﻿YamlDotNet.dll


### PR DESCRIPTION
- RenderHandlers changed the graphic device's render target, but never restored it before returning. This caused some parts of the screen to render to the wrong surface
- RenderDrawData overrode multiple properties on the graphic's device without restoring all of them. This left Scissor testing active for the rest of the rendering which would black out arbitrary rectangles on the screen.